### PR TITLE
break from read loop when underlying sockets is drained

### DIFF
--- a/source/botan/tls/blocking.d
+++ b/source/botan/tls/blocking.d
@@ -158,6 +158,8 @@ public:
 			}
 			else break;
 			const ubyte[] from_socket = m_read_fn(slice);
+			if (from_socket.length == 0)
+				break;
 			enforce(channel !is null, "Connection closed while reading from TLS Channel");
 			channel.receivedData(cast(const(ubyte)*)from_socket.ptr, from_socket.length);
 


### PR DESCRIPTION
This should fix a bug where an application of mine gets regularly stuck in a busy loop, b/c a requested remote server ends the connection early.