### PR TITLE
Improve Travis CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,25 @@
 language: d
 
 d:
-  - dmd-2.071.0
-  - dmd-2.070.0
-  - dmd-2.069.0
+  - dmd-nightly
+  - dmd-beta
+  - dmd
+  - dmd-2.074.0
+  - dmd-2.072.2
   - dmd-2.068.2
-  - dmd-2.067.1
-  - ldc-0.16.1
+  - ldc-beta
+  - ldc
+  - ldc-1.2.0
+  - ldc-0.17.3
+  - gdc
 
 matrix:
   allow_failures:
-      - d: dmd-2.067.1
-      - d: ldc-0.16.1
+      - d: ldc-beta
+      - d: ldc
+      - d: ldc-1.2.0
+      - d: ldc-0.17.3
+      - d: gdc
 
 script:
   - dub test :base


### PR DESCRIPTION
After running in a segmentation fault when running the Dub registry with Botan and LDC, I thought it's a __very good__ idea to improve the CI infrastructure (see e.g. https://github.com/dlang/dub-registry/issues/213). Thus PR updates the Travis file to use non-hardcoded versions, s.t. combined with daily crons (e.g. https://blog.travis-ci.com/2016-12-06-the-crons-are-here, go to https://travis-ci.org/etcimon/botan/settings for setup) regressions can be prevented / detected _before production_.

I also removed some DMD & LDC versions, as the main interesting ones are the latest main release, beta, nightly and a few important stables (last C++ version, first one with fixed imports) and there's no need to test that many "deprecated" (aka unused) versions from the past.


