### PR TITLE
AppVeyor: Exclude LDC from 32-bit builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,13 +21,7 @@ environment:
     arch: x86
   - DC: ldc
     DVersion: beta
-    arch: x86
-  - DC: ldc
-    DVersion: beta
     arch: x64
-  - DC: ldc
-    DVersion: stable
-    arch: x86
   - DC: ldc
     DVersion: stable
     arch: x64


### PR DESCRIPTION
Follow-up to https://github.com/etcimon/botan/pull/31

Interestingly DUB automagically recognices `m32mscoff` on Windows :)

![image](https://cloud.githubusercontent.com/assets/4370550/26553635/df831f78-448c-11e7-9f4f-3a4a538738a4.png)

However, `ldc` doesn't seem to know about this.

```
ldc2: Unknown command line argument '-m32mscoff'
```

So for now I think the easiest is to disable 32-bit LDC builds on Windows.