### PR TITLE
Fix dub.json

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -6,9 +6,10 @@
     "targetName": "botan",
     "targetType": "staticLibrary",
     "targetPath": "build",
-    "dependencies": {"memutils": { "version": "~>1.0.1" },
-				"botan-math": { "version": "~>1.0.2" } 
-            }, 
+    "dependencies": {
+        "memutils": { "version": "~>1.0.1" },
+        "botan-math": { "version": "~>1.0.2" } 
+    }, 
     "workingDirectory": ".",
     "sourcePaths": [
                 "source/botan/algo_base",
@@ -37,14 +38,14 @@
                 "source/botan/simd",
                 "source/botan/stream",
                 "source/botan/utils",
-		"source/botan/compression",
-		"source/botan/passhash",
-		"source/botan/tls"
+                "source/botan/compression",
+                "source/botan/passhash",
+                "source/botan/tls"
             ],
             "sourceFiles": [
                 "source/botan/constants.d",
                 "source/botan/test.d",
-				"source/botan/all.d"
+                "source/botan/all.d"
             ],
             "versions": ["Have_botan", "Botan"],
             "libs-posix": ["dl"],
@@ -53,17 +54,26 @@
             "configurations": [
                 {
                     "name": "full",
-					"versions": [
-						"CanTest", "SHA2_32", "SHA2_64", "MD4", "MD5", "SHA1", "CRC24", "PBKDF1", "PBKDF2", "CTR_BE", "HMAC", "POLY1305", "EMSA1", "EMSA1_BSI", "EMSA_X931", "EMSA_PKCS1", "EMSA_PSSR", "EMSA_RAW", "EME_OAEP", "EME_PKCS1v15", "PBE_PKCSv20", "Self_Tests", "ECB", "CBC", "XTS", "OFB", "CFB", "AEAD_FILTER", "AEAD_CCM", "AEAD_EAX", "AEAD_OCB", "AEAD_GCM", "AEAD_SIV", "AEAD_CHACHA20_POLY1305", "RFC6979", "RSA", "RW", "DLIES", "DSA", "ECDSA", "ElGamal", "GOST_3410", "Curve25519", "Nyberg_Rueppel", "Diffie_Hellman", "ECDH", "AES", "Blowfish", "Camellia", "CAST", "Cascade", "DES", "GOST_28147", "IDEA", "KASUMI", "LION", "MARS", "MISTY1", "NOEKEON", "RC2", "RC5", "RC6", "SAFER", "SEED", "Serpent", "TEA", "Twofish", "Threefish", "XTEA", "Adler32",  "CRC32", "GOST_3411", "HAS_160", "Keccak", "MD2",  "RIPEMD_128", "RIPEMD_160", "SHA2_64", "Skein_512", "Tiger", "Whirlpool", "ParallelHash", "Comb4P", "CBC_MAC", "CMAC", "SSL3_MAC", "ANSI_X919_MAC", "RC4", "ChaCha", "Salsa20", "Serpent_SIMD",  "SIMD_Scalar", "Noekeon_SIMD", "XTEA_SIMD", "Engine_AES_ISA", "Entropy_DevRand", "Entropy_EGD", "Entropy_UnixProc", "Entropy_Win32", "Entropy_ProcWalk", "X931_RNG", "HMAC_DRBG", "KDF1", "KDF2", "SSL_V3_PRF", "TLS_V10_PRF", "TLS_V12_PRF", "X942_PRF", "TLS", "X509", "PUBKEY", "FPE_FE1", "RFC3394", "PassHash9", "BCrypt", "SRP6", "TSS", "CryptoBox", "CryptoBox_PSK"
+                    "versions": [
+                        "CanTest", "SHA2_32", "SHA2_64", "MD4", "MD5", "SHA1", "CRC24", "PBKDF1", "PBKDF2", "CTR_BE", "HMAC", "POLY1305", "EMSA1", "EMSA1_BSI", "EMSA_X931", "EMSA_PKCS1", "EMSA_PSSR", "EMSA_RAW", "EME_OAEP", "EME_PKCS1v15", "PBE_PKCSv20", "Self_Tests", "ECB", "CBC", "XTS", "OFB", "CFB", "AEAD_FILTER", "AEAD_CCM", "AEAD_EAX", "AEAD_OCB", "AEAD_GCM", "AEAD_SIV", "AEAD_CHACHA20_POLY1305", "RFC6979", "RSA", "RW", "DLIES", "DSA", "ECDSA", "ElGamal", "GOST_3410", "Curve25519", "Nyberg_Rueppel", "Diffie_Hellman", "ECDH", "AES", "Blowfish", "Camellia", "CAST", "Cascade", "DES", "GOST_28147", "IDEA", "KASUMI", "LION", "MARS", "MISTY1", "NOEKEON", "RC2", "RC5", "RC6", "SAFER", "SEED", "Serpent", "TEA", "Twofish", "Threefish", "XTEA", "Adler32",  "CRC32", "GOST_3411", "HAS_160", "Keccak", "MD2",  "RIPEMD_128", "RIPEMD_160", "Skein_512", "Tiger", "Whirlpool", "ParallelHash", "Comb4P", "CBC_MAC", "CMAC", "SSL3_MAC", "ANSI_X919_MAC", "RC4", "ChaCha", "Salsa20", "Serpent_SIMD",  "SIMD_Scalar", "Noekeon_SIMD", "XTEA_SIMD", "Engine_AES_ISA", "Entropy_DevRand", "Entropy_EGD", "Entropy_UnixProc", "Entropy_Win32", "Entropy_ProcWalk", "X931_RNG", "HMAC_DRBG", "KDF1", "KDF2", "SSL_V3_PRF", "TLS_V10_PRF", "TLS_V12_PRF", "X942_PRF", "TLS", "X509", "PUBKEY", "FPE_FE1", "RFC3394", "PassHash9", "BCrypt", "SRP6", "TSS", "CryptoBox", "CryptoBox_PSK"
                     ],
                     "versions-x86_64": [
                         "Engine_ASM", "Entropy_Rdrand", "Entropy_HRTimer", "SHA1_x86_64","AES_NI", "SIMD_SSE2", "AES_SSSE3",  "IDEA_SSE2", "SHA1_SSE2", "Engine_SIMD", "ZLib"
                     ],
                     "versions-x86": [
-                        "Entropy_Rdrand", "Entropy_HRTimer", "Serpent_x86_32", "MD4_x86_32", "MD5_x86_32", "SHA1_x86_32", "Engine_SIMD", "Engine_ASM"
-                        
+                        "Entropy_Rdrand", "Entropy_HRTimer", "Serpent_x86_32", "MD4_x86_32", "MD5_x86_32", "SHA1_x86_32", "Engine_ASM"
                     ]
-                }, 
+                },
+                {
+                    "name": "full_32mscoff",
+                    "versions": [
+                        "CanTest", "SHA2_32", "SHA2_64", "MD4", "MD5", "SHA1", "CRC24", "PBKDF1", "PBKDF2", "CTR_BE", "HMAC", "POLY1305", "EMSA1", "EMSA1_BSI", "EMSA_X931", "EMSA_PKCS1", "EMSA_PSSR", "EMSA_RAW", "EME_OAEP", "EME_PKCS1v15", "PBE_PKCSv20", "Self_Tests", "ECB", "CBC", "XTS", "OFB", "CFB", "AEAD_FILTER", "AEAD_CCM", "AEAD_EAX", "AEAD_OCB", "AEAD_GCM", "AEAD_SIV", "AEAD_CHACHA20_POLY1305", "RFC6979", "RSA", "RW", "DLIES", "DSA", "ECDSA", "ElGamal", "GOST_3410", "Curve25519", "Nyberg_Rueppel", "Diffie_Hellman", "ECDH", "AES", "Blowfish", "Camellia", "CAST", "Cascade", "DES", "GOST_28147", "IDEA", "KASUMI", "LION", "MARS", "MISTY1", "NOEKEON", "RC2", "RC5", "RC6", "SAFER", "SEED", "Serpent", "TEA", "Twofish", "Threefish", "XTEA", "Adler32",  "CRC32", "GOST_3411", "HAS_160", "Keccak", "MD2",  "RIPEMD_128", "RIPEMD_160", "Skein_512", "Tiger", "Whirlpool", "ParallelHash", "Comb4P", "CBC_MAC", "CMAC", "SSL3_MAC", "ANSI_X919_MAC", "RC4", "ChaCha", "Salsa20", "Serpent_SIMD",  "SIMD_Scalar", "Noekeon_SIMD", "XTEA_SIMD", "Engine_AES_ISA", "Entropy_DevRand", "Entropy_EGD", "Entropy_UnixProc", "Entropy_Win32", "Entropy_ProcWalk", "X931_RNG", "HMAC_DRBG", "KDF1", "KDF2", "SSL_V3_PRF", "TLS_V10_PRF", "TLS_V12_PRF", "X942_PRF", "TLS", "X509", "PUBKEY", "FPE_FE1", "RFC3394", "PassHash9", "BCrypt", "SRP6", "TSS", "CryptoBox", "CryptoBox_PSK",
+                        "Entropy_Rdrand", "Entropy_HRTimer", "Serpent_x86_32", "MD4_x86_32", "MD5_x86_32", "SHA1_x86_32", "Engine_ASM"
+                    ],
+                    "subConfigurations": {
+                        "botan-math": "32mscoff"
+                    }
+                },
                 {
                     "name": "full_openssl",
                     "versions-x86_64": [


### PR DESCRIPTION
In order to compile on x86, dub.json needs to specify subconfigurations of botan_math.
However, the platform cannot be specified in subConfigurations, so a new configuration must be created.

In conjunction with #53, the changes can be made to pass the build and test on windows-x86_mscoff-dmd.

There have been reports of the following builds failing, but I think that at least the build method in windows-x86_mscoff-dmd will be resolved:
https://github.com/etcimon/botan/issues/3
https://github.com/etcimon/botan/issues/49