### PR TITLE
Partially fix OCSP validation

### DIFF
--- a/source/botan/asn1/asn1_time.d
+++ b/source/botan/asn1/asn1_time.d
@@ -249,6 +249,8 @@ public:
             throw new InvalidArgument("Invalid time specification " ~ t_spec);
     }
 
+    this() {}
+
     /*
     * Create a X509Time from a time point
     */

--- a/source/botan/cert/x509/ocsp.d
+++ b/source/botan/cert/x509/ocsp.d
@@ -88,6 +88,13 @@ public:
          const(X509Certificate)* issuer,
          in string response_bits)
     {
+        this.trusted_roots = trusted_roots;
+        this.issuer = issuer;
+        this.response_bits = response_bits;
+    }
+
+    void check()
+    {
         Vector!ubyte response_vec = Vector!ubyte(response_bits);
         BERDecoder response_outer = BERDecoder(response_vec).startCons(ASN1Tag.SEQUENCE);
         
@@ -185,6 +192,9 @@ public:
         return m_responses.length == 0;
     }
 private:
+    const(CertificateStore) trusted_roots;
+    const(X509Certificate)* issuer;
+    string response_bits;
     Vector!( SingleResponse ) m_responses;
 }
 
@@ -301,5 +311,6 @@ struct OnlineCheck {
 		*cast(OCSPResponse*)resp = OCSPResponse(*(cast(CertificateStore*)trusted_roots),
             issuer is subject ? null : issuer,
             res._body());
+        resp.check();
 	}
 }

--- a/source/botan/cert/x509/ocsp.d
+++ b/source/botan/cert/x509/ocsp.d
@@ -275,7 +275,7 @@ struct OnlineCheck {
 			*cast(OCSPResponse*)resp = OCSPResponse.init;
 			return;
 		}
-		responder_url = (*cast(X509Certificate*)issuer).ocspResponder();
+		responder_url = (*cast(X509Certificate*)subject).ocspResponder();
 	    logTrace("Responder url: ", responder_url.length);
 
 	    if (responder_url.length == 0) {

--- a/source/botan/cert/x509/x509cert.d
+++ b/source/botan/cert/x509/x509cert.d
@@ -273,7 +273,7 @@ public:
     */
     string ocspResponder() const
     {
-        //logTrace("Find OSCP responder in DataStore: ", m_subject.toString());
+        //logTrace("Find OCSP responder in DataStore: ", m_subject.toString());
         return m_subject.get1("OCSP.responder", "");
     }
 

--- a/source/botan/cert/x509/x509path.d
+++ b/source/botan/cert/x509/x509path.d
@@ -510,7 +510,7 @@ Vector!( RBTreeRef!CertificateStatusCode )
 	            if (ocsp_status == CertificateStatusCode.CERT_IS_REVOKED)
 	                return cert_status.move();
 			} else logTrace("OCSP not found");
-		} catch (Exception e) { logTrace("OSCP failed with ", e.msg); }
+		} catch (Exception e) { logTrace("OCSP failed with ", e.msg); }
         
         const X509CRL crl = findCrlsFor(subject, certstores);
         


### PR DESCRIPTION
I am thoroughly confused.

This library is advertised ([here](https://github.com/etcimon/botan/blob/master/README.md) and [here](https://forum.dlang.org/post/mc0a99$2bfn$1@digitalmars.com)) as including a TLS client. However, upon trying to use the TLS client functionality in the most obvious way possible, namely making a simple HTTPS request, I've encountered numerous obstacles.

The first was the sheer amount of boilerplate required for the most basic functionality. It looks like all users of the library are expected to subclass `TLSCredentialsManager`, and even when they don't need to customize any of its functionality, "implement" all methods as stubs that call the parent class methods (which are all, for some reason, marked `abstract`). In my opinion, the more exposed knobs you have, the more opportunity there are for users to get something wrong; ideally, the library should provide a simple interface with some good defaults at the time of writing.

The second was lack of any functionality for using the host system's trusted root certificate authority store. OK, maybe this is understandable as this is a platform-specific detail that's hard to stay on top of; in any case, easily solved by packaging a [trusted root CA bundle](https://raw.githubusercontent.com/bagder/ca-bundle/master/ca-bundle.crt) with your application (just remember to keep it updated).

The third was that OCSP validation, which, AFAIU, in lieu of a CRL, is a necessary part of validating the certificate chain, is completely broken. I can't see how the HTTP code for making OCSP requests could have ever worked at all. I'm not sure if this was a translation error or if it was broken in the C++ version too. OCSP validation also cannot apparently be turned off without entirely foregoing validation of the certificate chain; the only exposed switch is whether to validate the entire chain or just the first (youngest) certificate.

I had a look at what Vibe.d does. As far as I understand, the Vibe.d implementation simply does not validate the certificate chain, successfully establishing the connection whether it's secure or not. I could find no references to the `tcp_message_handler` hook, necessary for implementing OCSP validation, [anywhere on GitHub](https://github.com/search?l=D&q=tcp_message_handler&type=Code). Am I really the first who has attempted to use botan's TLS client the "proper" way? Or have I made some gigantic misstep somewhere above?

In any case, here are some commits which I think improve the situation. I still don't have things quite working yet; the current obstacle seems to be that the OCSP response is signed with a certificate which is not available to Botan. (I would think that would simply be the issuer certificate, as the CN seems to imply, but apparently that one isn't flagged for the use of signing OCSP responses.)