### PR TITLE
Workaround of wrong foreach inference

### DIFF
--- a/source/botan/tls/channel.d
+++ b/source/botan/tls/channel.d
@@ -571,13 +571,13 @@ protected:
             // TLS is easy just remove all but the current state
             auto current_epoch = sequenceNumbers().currentWriteEpoch();
 
-            foreach (const ref ushort k, const ref ConnectionCipherState v; m_write_cipher_states) {
+            foreach (const ref ushort k, const ref ConnectionCipherState v; cast(const)m_write_cipher_states) {
                 if (k != current_epoch) {
                     v.destroy();
                     m_write_cipher_states.remove(k);
                 }
             }
-            foreach (const ref ushort k, const ref ConnectionCipherState v; m_read_cipher_states) {
+            foreach (const ref ushort k, const ref ConnectionCipherState v; cast(const)m_read_cipher_states) {
                 if (k != current_epoch) {
                     v.destroy();
                     m_write_cipher_states.remove(k);                    
@@ -836,12 +836,12 @@ private:
         m_pending_state.free();
         m_readbuf.destroy();
 		m_writebuf.destroy();
-        foreach (const ref k, const ref v; m_write_cipher_states)
+        foreach (const ref k, const ref v; cast(const)m_write_cipher_states)
         {
             v.destroy();
         }
         m_write_cipher_states.clear();
-        foreach (const ref k, const ref v; m_read_cipher_states)
+        foreach (const ref k, const ref v; cast(const)m_read_cipher_states)
         {
             v.destroy();
         }


### PR DESCRIPTION
In dmd 2.099.0-beta.1, I get four errors similar to the following.
This pull request is a workaround.

```
source\botan\tls\channel.d(574,13): Error: `memutils.hashmap.HashMap!(ushort, ConnectionCipherState, ThreadMem).HashMap.opApply` called with argument types `(int delegate(ref const(ushort) k, ref const(ConnectionCipherState) v) @system)` matches both:
\dub\packages\memutils-1.0.4\memutils\source\memutils\hashmap.d(153,6):     `memutils.hashmap.HashMap!(ushort, ConnectionCipherState, ThreadMem).HashMap.opApply(int delegate(ref const(ushort), ref ConnectionCipherState) del)`
and:
\dub\packages\memutils-1.0.4\memutils\source\memutils\hashmap.d(162,6):     `memutils.hashmap.HashMap!(ushort, ConnectionCipherState, ThreadMem).HashMap.opApply(int delegate(in ref ushort, in
 ref ConnectionCipherState) del) const`
```