### PR TITLE
Update lzma.d

### DIFF
--- a/source/botan/compression/lzma.d
+++ b/source/botan/compression/lzma.d
@@ -106,7 +106,9 @@ public:
     ~this()
     {
         .lzma_end(streamp());
-        delete streamp().allocator;
+    	auto a = streamp().allocator;
+	destroy(a);
+	GC.free(cast(void*) a);
     }
     
     override bool run(uint flags)


### PR DESCRIPTION
`delete` is deprecated and is not working on `latest ldc-1.41.0-beta1`
Use `destroy()` instead.

https://dlang.org/deprecate.html#delete