### PR TITLE
increase default bcrypt work factor

### DIFF
--- a/source/botan/passhash/bcrypt.d
+++ b/source/botan/passhash/bcrypt.d
@@ -32,7 +32,7 @@ import std.conv : to;
 */
 string generateBcrypt(in string password,
                       RandomNumberGenerator rng,
-                      ushort work_factor = 10)
+                      ushort work_factor = 12)
 {
     return makeBcrypt(password, unlock(rng.randomVec(16)), work_factor);
 }


### PR DESCRIPTION
It has been 10 years since this default work factor was set in the code, it's probably about time to quadruple the time it takes again.

[This random person benchmarked](https://stackoverflow.com/a/75691338) it on a modern-ish CPU and on cloud servers in 2023 and it seems like 12 is a good default now (taking around 200-400ms per hash - the original implementation suggests at least 250ms)